### PR TITLE
Valencia

### DIFF
--- a/src/AlgorithmStrategyEnums.jl
+++ b/src/AlgorithmStrategyEnums.jl
@@ -28,8 +28,6 @@ Scoped enumeration (using EnumX) representing different jet algorithms used in t
 - `Durham`: The e+e- kt algorithm, aka Durham.
 - 'Valencia': The generalized e⁺e⁻ jet algorithm designed to reduce soft contamination and improve performance in forward regions. 
 """
-
-
 @enumx T=Algorithm JetAlgorithm AntiKt CA Kt GenKt EEKt Durham Valencia
 const AllJetRecoAlgorithms = [String(Symbol(x)) for x in instances(JetAlgorithm.Algorithm)]
 
@@ -100,7 +98,6 @@ function get_algorithm_power_consistency(; p::Union{Real, Nothing},
         return (p = 1, algorithm = algorithm)
     end
 
-    #changes: implement inverse energy dependence
 
     if algorithm == JetAlgorithm.Valencia
         return (p = 1, algorithm = algorithm)

--- a/src/AlgorithmStrategyEnums.jl
+++ b/src/AlgorithmStrategyEnums.jl
@@ -26,8 +26,11 @@ Scoped enumeration (using EnumX) representing different jet algorithms used in t
 - `GenKt`: The Generalised Kt algorithm (with arbitrary power).
 - `EEKt`: The Generalised e+e- kt algorithm.
 - `Durham`: The e+e- kt algorithm, aka Durham.
+- 'Valencia': The generalized e⁺e⁻ jet algorithm designed to reduce soft contamination and improve performance in forward regions. 
 """
-@enumx T=Algorithm JetAlgorithm AntiKt CA Kt GenKt EEKt Durham
+
+
+@enumx T=Algorithm JetAlgorithm AntiKt CA Kt GenKt EEKt Durham Valencia
 const AllJetRecoAlgorithms = [String(Symbol(x)) for x in instances(JetAlgorithm.Algorithm)]
 
 """
@@ -97,6 +100,12 @@ function get_algorithm_power_consistency(; p::Union{Real, Nothing},
         return (p = 1, algorithm = algorithm)
     end
 
+    #changes: implement inverse energy dependence
+
+    if algorithm == JetAlgorithm.Valencia
+        return (p = 1, algorithm = algorithm)
+    end
+
     # Otherwise we check the consistency between the algorithm and power
     if !isnothing(algorithm)
         power_from_alg = algorithm2power[algorithm]
@@ -147,8 +156,9 @@ Check if the algorithm is a e+e- reconstruction algorithm.
 # Returns
 `true` if the algorithm is a e+e- reconstruction algorithm, `false` otherwise.
 """
+
 function is_ee(algorithm::JetAlgorithm.Algorithm)
-    return algorithm in [JetAlgorithm.EEKt, JetAlgorithm.Durham]
+    return algorithm in [JetAlgorithm.EEKt, JetAlgorithm.Durham, JetAlgorithm.Valencia]
 end
 
 """

--- a/src/READMe
+++ b/src/READMe
@@ -1,0 +1,64 @@
+# === Valencia Algorithm Integration ===
+# Summary:
+# This implementation adds full support for the Valencia jet algorithm,
+# a sequential recombination algorithm designed for e⁺e⁻ colliders
+# with improved background rejection in forward regions.
+
+# Valencia's distance metrics:
+#   Inter-particle:
+#     d_ij = min(E_i^{2β}, E_j^{2β}) * (1 - cosθ_ij) / R^2
+#
+#   Beam distance:
+#     d_iB = E_i^{2β} * (1 - cosθ_iB)^β
+
+# Key Implementation Details:
+
+# (1) src/AlgorithmStrategyEnums.jl
+#   - Added `Valencia` to JetAlgorithm enum
+#   - Updated `is_ee(...)` to return true for Valencia
+
+# (2) src/EEAlgorithm.jl — in `ee_genkt_algorithm(...)` and `_ee_genkt_algorithm(...)`
+#   - Set dij_factor = 1 / R^2 for Valencia
+#   - Set energy exponent `p = β` to build E^{2β} terms for clustering
+#   - Modified beam distance logic:
+#       → For Valencia, compute: d_iB = E^{2β} * (1 - cosθ)^β
+#       → Use z-axis alignment to compute cosθ from direction cosine nz
+#       → If d_iB < d_ij, mark jet to merge with beam via nni[i] = 0
+
+# (3) Reused existing functions for distance calculation:
+#   - dij_dist(...) and angular_distance(...) already supported general structure
+#   - Only beam distance logic and dij_factor needed Valencia-specific edits
+
+# Result:
+# The algorithm now performs full Valencia-style clustering, suppressing
+# isolated forward particles and maintaining Durham-like structure in the central region.
+
+# Future:
+# To make β configurable at runtime, expose it as a keyword argument in ee_genkt_algorithm(...).
+
+# How it all comes together:
+# The preprocessing step raises all particle energies to 2β and stores them in E2p,
+# dij_dist(...) uses that and angular distance scaled by 1/R² to compute d_ij,
+# and the main clustering loop compares that against d_iB — calculated from
+# E2p and cos(θ) — to decide whether a particle is merged with another jet or
+# discarded into the beam. This fully reproduces the intended Valencia behavior.
+
+
+
+
+# Valencia algorithm successfully implemented:
+# 1. Added `Valencia` to JetAlgorithm enum (AlgorithmStrategyEnums.jl).
+# 2. Treated Valencia as an e+e- type algorithm in `is_ee(...)`.
+# 3. Implemented Valencia beam distance in `EEAlgorithm.jl` as:
+#    d_iB = (E_i^2 * (1 - cosθ_i))^β / R^2
+# 4. Incorporated it into the clustering loop by comparing
+#    beam distance to current nearest-neighbor dij.
+# 5. Preserved logic structure from EEKt, reusing merge-to-beam
+#    logic (`dijdist[i]`, `nni[i] = 0`) when appropriate.
+# 6. Verified implementation via full test suite; all tests passed.
+
+# Final note: The full Valencia algorithm works by plugging into the
+# generic `jet_reconstruct()` interface, which delegates e+e- style
+# clustering to `ee_genkt_algorithm(...)`. That in turn uses the modified
+# distance measures and beam merging logic now defined for Valencia,
+# thus completing the end-to-end reconstruction pipeline.

--- a/src/READMe
+++ b/src/READMe
@@ -1,64 +1,36 @@
-# === Valencia Algorithm Integration ===
-# Summary:
-# This implementation adds full support for the Valencia jet algorithm,
-# a sequential recombination algorithm designed for e⁺e⁻ colliders
-# with improved background rejection in forward regions.
+Implementing the Valencia Algorithm in Julia:
 
-# Valencia's distance metrics:
-#   Inter-particle:
-#     d_ij = min(E_i^{2β}, E_j^{2β}) * (1 - cosθ_ij) / R^2
-#
-#   Beam distance:
-#     d_iB = E_i^{2β} * (1 - cosθ_iB)^β
+The valencia algorithm is a variation of the generalized EEkt algorithm. Using the preexisting scaffolding
+for jet reconstruction algorithms in JetReconstruction.jl, we were able to seemlesly implement Valencia. This was done by updating the conditionals that make the program run. When called on a set of particles and a specific algorithm name, this program currently performs jet reconstruction on that data and outputs 
+parameters describing the resultant jets. We simply needed to updated the functions used in this program to 
+take on an extra case under the name "valencia." The main differences in this algorithm are the particle-to-
+beam distance calculation and the inter particle distance calculation. 
 
-# Key Implementation Details:
+The particle-to-beam distance (diB) calculation is p(t)^2beta or `diB = E^(2β) * sin(θ)^(2β)`
 
-# (1) src/AlgorithmStrategyEnums.jl
-#   - Added `Valencia` to JetAlgorithm enum
-#   - Updated `is_ee(...)` to return true for Valencia
+- Here, E is the energy of the particle, theta is the angle between the particles momentum and beam axis, and beta is a tunable parameter that controls clustering behavior
 
-# (2) src/EEAlgorithm.jl — in `ee_genkt_algorithm(...)` and `_ee_genkt_algorithm(...)`
-#   - Set dij_factor = 1 / R^2 for Valencia
-#   - Set energy exponent `p = β` to build E^{2β} terms for clustering
-#   - Modified beam distance logic:
-#       → For Valencia, compute: d_iB = E^{2β} * (1 - cosθ)^β
-#       → Use z-axis alignment to compute cosθ from direction cosine nz
-#       → If d_iB < d_ij, mark jet to merge with beam via nni[i] = 0
+The interparticle distance (dij) calculation is `dij = min(Ei^(2β), Ej^(2β)) * (1 - cos(θij)) / R^2`
 
-# (3) Reused existing functions for distance calculation:
-#   - dij_dist(...) and angular_distance(...) already supported general structure
-#   - Only beam distance logic and dij_factor needed Valencia-specific edits
+- Here, Ei and Ej are the energies of the two particles, theta is the angle between their momentum vectors, and R is the jet radius parameter
 
-# Result:
-# The algorithm now performs full Valencia-style clustering, suppressing
-# isolated forward particles and maintaining Durham-like structure in the central region.
 
-# Future:
-# To make β configurable at runtime, expose it as a keyword argument in ee_genkt_algorithm(...).
+In JetReconstruction.jl:
 
-# How it all comes together:
-# The preprocessing step raises all particle energies to 2β and stores them in E2p,
-# dij_dist(...) uses that and angular distance scaled by 1/R² to compute d_ij,
-# and the main clustering loop compares that against d_iB — calculated from
-# E2p and cos(θ) — to decide whether a particle is merged with another jet or
-# discarded into the beam. This fully reproduces the intended Valencia behavior.
+Updates to EEAlgorithm.jl: 
+- The beta parameter was introduced as an argument in the relevant functions (`ee_genkt_algorithm`, `_ee_genkt_algorithm`, and `get_angular_nearest_neighbours!`)
+- a default beta value of 1.0 was set for compatability
+- the particle-to-beam (diB) and the inter-particle distance (dij) were modified to include the Valencia specific formulas 
+- The changes in calculation were wrapped in conditionals only to be used when JetAlgorithm.Valencia is called 
+
+Updates to AlgorithmStrategyEnums.jl:
+
+- The 'JetAlgorithm' enum was updated to include a new case for Valencia
+
+Usage: 
+To use the Valencia algorithm for jet reconstruction, specift the algorithm name and optionally provide a value for beta...
+
+"jets = ee_genkt_algorithm(particles; algorithm = JetAlgorithm.Valencia, beta = 1.0, R = 1.0)"
 
 
 
-
-# Valencia algorithm successfully implemented:
-# 1. Added `Valencia` to JetAlgorithm enum (AlgorithmStrategyEnums.jl).
-# 2. Treated Valencia as an e+e- type algorithm in `is_ee(...)`.
-# 3. Implemented Valencia beam distance in `EEAlgorithm.jl` as:
-#    d_iB = (E_i^2 * (1 - cosθ_i))^β / R^2
-# 4. Incorporated it into the clustering loop by comparing
-#    beam distance to current nearest-neighbor dij.
-# 5. Preserved logic structure from EEKt, reusing merge-to-beam
-#    logic (`dijdist[i]`, `nni[i] = 0`) when appropriate.
-# 6. Verified implementation via full test suite; all tests passed.
-
-# Final note: The full Valencia algorithm works by plugging into the
-# generic `jet_reconstruct()` interface, which delegates e+e- style
-# clustering to `ee_genkt_algorithm(...)`. That in turn uses the modified
-# distance measures and beam merging logic now defined for Valencia,
-# thus completing the end-to-end reconstruction pipeline.

--- a/valencia_example.jl
+++ b/valencia_example.jl
@@ -1,0 +1,24 @@
+println("Starting Valencia test script...")
+
+using LorentzVectorHEP
+println("Loaded LorentzVectorHEP")
+
+using JetReconstruction
+println("Loaded JetReconstruction")
+
+# Create 3 example particles in a cone
+particles = [
+    LorentzVector(50.0, 10.0, 0.0, sqrt(50.0^2 - 10.0^2)),
+    LorentzVector(40.0, -10.0, 0.0, sqrt(40.0^2 - 10.0^2)),
+    LorentzVector(20.0, 0.0, 50.0, sqrt(20.0^2 + 50.0^2))
+]
+println("Defined 3 particles")
+
+# Use the Valencia algorithm with β = 1.0 and R = 1.0
+jets = jet_reconstruct(particles; algorithm=JetAlgorithm.Valencia, p=1.0, R=1.0)
+
+# Print result
+println("Reconstructed jets:")
+for jet in inclusive_jets(jets)
+    println(jet)
+end


### PR DESCRIPTION
This PR introduces the Valencia algorithm into the JetReconstruction.jl framework. The implementation includes:
- Modified beam distance computation based on E^{2β} sin²θ^β
- Updated dij normalization (1/R²) for angular distances
- A test example script `valencia_example.jl` demonstrating basic usage

Based on the algorithm described in:  
Boronat et al., Eur. Phys. J. C (2015) 75: 371 [https://arxiv.org/abs/1404.4294]